### PR TITLE
v2.0.0 updates and refactoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,52 +1,56 @@
 {
   "name": "ipwatch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "any-promise": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
-      "integrity": "sha1-q8av7tzqUugJzcA3au0845Y10X8="
+    "@seald-io/binary-search-tree": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@seald-io/binary-search-tree/-/binary-search-tree-1.0.2.tgz",
+      "integrity": "sha512-+pYGvPFAk7wUR+ONMOlc6A+LUN4kOCFwyPLjyaeS7wVibADPHWYJNYsNtyIAwjF1AXQkuaXElnIc4XjKt55QZA=="
+    },
+    "@seald-io/nedb": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@seald-io/nedb/-/nedb-2.2.0.tgz",
+      "integrity": "sha512-whkcx3hpcowNhoSEbIsrfe8TXxDwyj8SJJut2EqF7DSX2GGqQlL7Ix/vzwwOo4FJolzDhZD2DaUTVKmTQS3Rog==",
+      "requires": {
+        "@seald-io/binary-search-tree": "^1.0.2",
+        "async": "0.2.10",
+        "localforage": "^1.9.0"
+      },
+      "dependencies": {
+        "localforage": {
+          "version": "1.10.0",
+          "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+          "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+          "requires": {
+            "lie": "3.1.1"
+          }
+        }
+      }
     },
     "async": {
       "version": "0.2.10",
       "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
       "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
-    "axios": {
-      "version": "0.21.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.0.tgz",
-      "integrity": "sha512-fmkJBknJKoZwem3/IKSSLpkdNXZeBu5Q7GA/aRsr2btgrptmSCxi2oFjZHqGdK9DoTil9PIHlPIZw2EcRJXRvw==",
-      "requires": {
-        "follow-redirects": "^1.10.0"
-      }
-    },
-    "binary-search-tree": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/binary-search-tree/-/binary-search-tree-0.2.5.tgz",
-      "integrity": "sha1-fbs7IQ/coIJFDa0jNMMErzm9x4Q=",
-      "requires": {
-        "underscore": "~1.4.4"
-      }
-    },
     "debug": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
-      "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
       "requires": {
         "ms": "2.1.2"
       }
     },
     "dotenv": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
-      "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
     },
     "follow-redirects": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.13.0.tgz",
-      "integrity": "sha512-aq6gF1BEKje4a9i9+5jimNFIpq4Q1WiwBToeRK5NvZBd/TRsmW8BsJfOEGkr76TbOyPVD3OVDN910EcUNtRYEA=="
+      "version": "1.14.5",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.5.tgz",
+      "integrity": "sha512-wtphSXy7d4/OR+MvIFbCVBDzZ5520qV8XfPklSN5QtxuMUJZ+b0Wnst1e1lCDocfzuCkHqj8k0FpZqO+UIaKNA=="
     },
     "immediate": {
       "version": "3.0.6",
@@ -61,109 +65,68 @@
         "immediate": "~3.0.5"
       }
     },
-    "localforage": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.7.4.tgz",
-      "integrity": "sha512-3EmVZatmNVeCo/t6Te7P06h2alGwbq8wXlSkcSXMvDE2/edPmsVqTPlzGnZaqwZZDBs6v+kxWpqjVsqsNJT8jA==",
-      "requires": {
-        "lie": "3.1.1"
-      }
-    },
-    "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
-    },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "requires": {
-        "minimist": "^1.2.5"
-      }
-    },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
-    "nedb": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/nedb/-/nedb-1.8.0.tgz",
-      "integrity": "sha1-DjUCzYLABNU1WkPJ5VV3vXvZHYg=",
+    "nedb-promises": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/nedb-promises/-/nedb-promises-5.0.2.tgz",
+      "integrity": "sha512-087g8JdsStXRWDxC9qqE4qMLqZGJrUnYF54pvOCDDfcLoptJUCqGb7j2WvWlaleeqft9rUjiJ9egvMJlUnJTmA==",
       "requires": {
-        "async": "0.2.10",
-        "binary-search-tree": "0.2.5",
-        "localforage": "^1.3.0",
-        "mkdirp": "~0.5.1",
-        "underscore": "~1.4.4"
+        "@seald-io/nedb": "^2.2.0"
       }
     },
-    "nedb-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/nedb-promise/-/nedb-promise-2.0.1.tgz",
-      "integrity": "sha1-g5suSQlxb99pUAt/aLK4ciWCzWU=",
+    "node-fetch": {
+      "version": "2.6.6",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.6.tgz",
+      "integrity": "sha512-Z8/6vRlTUChSdIgMa51jxQ4lrw/Jy5SOW10ObaA47/RElsAN2c5Pn8bTgFGWn/ibwzXTE8qwr1Yzx28vsecXEA==",
       "requires": {
-        "nedb": "^1.8.0",
-        "thenify": "^3.2.0"
+        "whatwg-url": "^5.0.0"
       }
     },
     "postmark": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/postmark/-/postmark-2.6.0.tgz",
-      "integrity": "sha512-zL7y+jX4gkjn+EAWKOE0z2CNdR+51iBMYtycV75Ke2r58rFpNsU86pbuCEcNxVwH9J3da/UUMpxCgasBTm7xew==",
+      "version": "2.7.8",
+      "resolved": "https://registry.npmjs.org/postmark/-/postmark-2.7.8.tgz",
+      "integrity": "sha512-DvOLcgYSM5+NEKrdQsrpnkX9tAP/apZRMEL9Z0UjY2Fh9kBBhLMCAKm9hANSUeTugrmOiKe3DWu/tSSUIu2CIw==",
       "requires": {
-        "axios": "^0.19.2"
+        "axios": "^0.21.4"
       },
       "dependencies": {
         "axios": {
-          "version": "0.19.2",
-          "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
-          "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+          "version": "0.21.4",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
+          "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
           "requires": {
-            "follow-redirects": "1.5.10"
+            "follow-redirects": "^1.14.0"
           }
-        },
-        "debug": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "follow-redirects": {
-          "version": "1.5.10",
-          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-          "requires": {
-            "debug": "=3.1.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
     },
-    "thenify": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.0.tgz",
-      "integrity": "sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=",
-      "requires": {
-        "any-promise": "^1.0.0"
-      }
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
     },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ipwatch",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "A script to alert when IP changes",
   "main": "index.js",
   "scripts": {
@@ -16,11 +16,11 @@
   "author": "Brett Slaski",
   "license": "MIT",
   "dependencies": {
-    "axios": "^0.21.0",
-    "debug": "^4.3.1",
-    "dotenv": "^8.2.0",
-    "moment": "^2.26.0",
-    "nedb-promise": "^2.0.1",
-    "postmark": "^2.6.0"
+    "debug": "^4.3.2",
+    "dotenv": "^10.0.0",
+    "moment": "^2.29.1",
+    "nedb-promises": "^5.0.2",
+    "node-fetch": "^2.6.6",
+    "postmark": "^2.7.8"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -6,6 +6,8 @@ All pretty basic really.
 
 ## The GCP function
 
+This simple function is set up in GCP and pointed to by the server.js script. It returns the server headers as a json object.
+
 ```JavaScript
 /**
  * Responds to any HTTP request.
@@ -14,34 +16,34 @@ All pretty basic really.
  * @param {!express:Response} res HTTP response context.
  */
 exports.headerDump = (req, res) => {
-  const head = JSON.stringify(req.headers)
+  const head = req.headers
   delete head['if-none-match']
   delete head['x-appengine-default-version-hostname']
-  res.status(200).send(head)
+  res.status(200).json(head)
 };
 ```
 
 ## function
 
-On every run looks at data from endpoint and searches for the x-forwarded-for header value in the database.
+On each run the function looks at data from endpoint and searches for the `x-forwarded-for` header value in the database.
 
-- if found, add one to seen
-- if not found, send email add new record.
+- if found, add one to seen count
+- if not found, send email and add new record.
 
-Uses nedb and shouldn't grow large as it will only have as many records as IP's discovered. Which hopefully is very few or there are bigger issues with your crap ISP. 
+Uses nedb and shouldn't grow large as it will only have as many records as IP's discovered. Which hopefully is very few or there are bigger issues with your crap ISP.
 
 ## THANK YOU
 
 Thank you to these projects for their great work! I appreciate you.
 
-- [axios](https://www.npmjs.com/package/axios)
+- [node-fetch](https://www.npmjs.com/package/node-fetch)
 - [debug](https://www.npmjs.com/package/debug)
 - [dotenv](https://www.npmjs.com/package/dotenv)
 - [moment](https://www.npmjs.com/package/moment)
-- [nedb](https://www.npmjs.com/package/nedb) & [nedb-promise](https://www.npmjs.com/package/nedb-promise)
+- [nedb](https://www.npmjs.com/package/nedb) & [nedb-promises](https://www.npmjs.com/package/nedb-promises)
 - [postmark](https://postmarkapp.com), [node client lib](https://www.npmjs.com/package/postmark)
 
-Get off SendGrid, use [Postmark](https://postmarkapp.com), they are so much better. Yeah, more of a hassle to get started with, but to me that's worth it as it keeps the bad players off their service. Go check them out if you have a moment.
+Get off SendGrid, use [Postmark](https://postmarkapp.com), they are so much better. Yeah, more of a hassle to get started with, but to me that's worth it as it keeps the bad players off their service. Go check them out.
 
 ## Installation
 
@@ -57,14 +59,14 @@ EMAIL_TO=
 EMAIL_FROM=
 ```
 
-Using Postmark for email. I really like their service and they care about deliverability of their clients. Check them out if you have a moment.
+`ENDPOINT_CHK` is the endpoint of the function code. There is no file for the function at this time as it's really straight forward. Simply copy `GCP Function` listed above into a gcp function or even a CloudFlare worker online interface.
 
-`ENDPOINT_CHK` is the endpoint of the function code. There is no file for the function at this time as it's really straight forward. Simply apply `GCP Function` listed above into a gcp function or even a CloudFlare worker.
+`server.js` can be run anywhere there is node 12+ and write access to it's folder for the db file. This needs to run from somewhere within your network, calling out to the internet so the function can relay back your IP for recording.
 
-`server.js` can be run anywhere there is node 10+ and write access to it's folder for the db file. This needs to run from somewhere within your network, calling out to the internet so the function can relay back your IP for recording. 
-
-I have this running on my home Synology using a scheduled task to execute the node file. It does the job. 
+I have this running on my home Synology using a scheduled task to execute the node file. It does the job.
 
 ## In Use
 
-So earlier this our ISP sent a 'reset' code to fix something. It changed the IP being used and an email was sent as hoped. 😅 We were able to change references to keep cross location services running. 
+So earlier this our ISP sent a 'reset' code to fix something. It changed the IP being used and an email was sent as hoped. 😅 We were able to change DNS references to keep cross location services running.
+
+Perhaps a next version can update the DNS record in Cloudflare with the changed IP value. 🤔

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+node server.js


### PR DESCRIPTION
v2.0.0
update dependent package versions
replaced `nedb-promise` with `neb-promises` due to critical vulnerabilities with no update in 5 years
replaced `axios` with `node-fetch` to reduce dependencies and package size
update readme accordingly
refactored headerDump script (gcp function)
add simple shell script used in practice